### PR TITLE
Install pass to fix docker login

### DIFF
--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
         docker.io \
         npm \
         bsdtar \
-        docker-compose && \
+        docker-compose \
+        gnupg2 pass && \
     apt-get clean
 
 # Install kubectl


### PR DESCRIPTION
docker-compose apt package breaks default auth. It includes `golang-github-docker-docker-credential-helpers`, which breaks when you don't have X11.

We fix it by installing pass, since it is automatically used as credential helper. https://bugs.launchpad.net/ubuntu/+source/docker-compose/+bug/1796119